### PR TITLE
Ensure that the rhs column has a set width

### DIFF
--- a/index.php
+++ b/index.php
@@ -99,7 +99,7 @@
             <?php endif; ?>
             <!-- Post List -->
             <div class="row">
-                <div class="col">
+                <div class="col col-md-7 col-xxl-9">
                     <!-- Grid Layout -->
                     <?php if (have_posts() ) : ?>
                     <?php while (have_posts() ) : the_post(); ?>


### PR DESCRIPTION
The default for `col` is to have max-width set to 100%, sadly, this means that if there is content (such as a large image) that takes more then `calc(100%-25%)` of viewport, then the menu on the RHS will not show.

This tiny PR sets a width for the column, which ensures that the menu will appear on the RHS. Ideally, there would be a check here to ensure that the `col-md-7` is only applied when the sidebar has content.